### PR TITLE
Handled expiration date parsing exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+* Handled an exception caused by `_check_token()` trying to parse the expiration date from a token that never expires
+
 ## [3.0.1] - 17 May 2023
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [3.0.2] - 13 June 2023
 
 ### Fixed
 


### PR DESCRIPTION
Handled an exception caused by `_check_token()` trying to parse the expiration date from a token that never expires